### PR TITLE
create index.html to prevent default reverse proxy of widgetbot.io

### DIFF
--- a/packages/configurator/public/index.html
+++ b/packages/configurator/public/index.html
@@ -1,0 +1,1 @@
+/channels/<id>


### PR DESCRIPTION
Since this file is missing, by default, the server will try to reverse proxy from widgetbot.io, which makes it difficult to host it on your own domain. It created a lot of confusion for me, so this should help prevent that. 