### PR TITLE
Fix docker unable to build and reduce size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   server:
     build: .
+    restart: unless-stopped
     volumes:
       - ./packages/server/data/config.yml:/app/packages/server/data/config.yml
     ports:


### PR DESCRIPTION
Hi, there

I notice the `node:lts-alpine` is updated to Node 12+ but the packages required compile are unable to install because newer node.js did not provide pre-compiled version.

So I modify the Dockerfile to pre-compile and copy to the docker image, it can resolve the problem when the users are unable to download pre-compiled packages.

And below is other changes:

* Use `restart: unless-stopped` to ensure Widgetbot always running event it crashes
* Use `Stage` feature to build the image, the final image size is reduced to ~700MB