### PR TITLE
Update config.example.yml to indicate that jwt_secret is a required field

### DIFF
--- a/packages/server/data/config.example.yml
+++ b/packages/server/data/config.example.yml
@@ -6,10 +6,10 @@
 # COPY THIS FILE BEFORE EDITING TO `config.yml`
 
 database:
-  jwt_secret: ''  # TODO add long random string here for some encryption (DON'T share that string with anyone and don't add it to Git)
+  jwt_secret: ''  # REQUIRED add long random string here for some encryption (DON'T share that string with anyone and don't add it to Git)
 
 discord:
-  token: ''  # TODO add your Discord Bot's Token here
+  token: ''  # REQUIRED add your Discord Bot's Token here
 
   events:
     logs:   ['server-id', 'channel-id']  # TODO decide where to send server activity messages to (currently only guild create/delete)


### PR DESCRIPTION
Correctly indicate that jwt_secret is a required field, just like token. The difference being an invalid or missing token causes a visible error and an empty jwt_token causes silent and frustrating failure...

With an empty jwt_secret new clients are unable to register, and an empty error is displayed in the widget.